### PR TITLE
Update amazonAWS.cfc

### DIFF
--- a/amazonAWS.cfc
+++ b/amazonAWS.cfc
@@ -4,9 +4,8 @@
 		<cfargument name="date" required="false" default="#now()#" >
 		<cfargument name="iso" required="false" default="false" >
 		<cfset var result = '' />
-		<cfset tz = getTimeZoneInfo() />
-		<cfset dt = now() />
-		<cfset GDT=dateAdd('s',TZ.utcTotalOffset,DT) />
+		<cfset var tz = getTimeZoneInfo() />
+		<cfset var GDT=dateAdd('s',TZ.utcTotalOffset,arguments.date) />
 		<cfif arguments.iso>
 			<cfset result = DateFormat(GDT,'yyyy-mm-dd') & 'T' & TimeFormat(GDT,'HH:mm:ss')  & 'Z' />
 		<cfelse>	


### PR DESCRIPTION
- createFormattedTime was always using the DT var (now()) and ignored the arguments.date
  removed the unneeded DT variable and edited the code to use the argument instead of DT.
- Also var scoped all variables in the createFormattedTime
