### PR TITLE
Added init arg for endpoint to all CFCs

### DIFF
--- a/amazonAlexa.cfc
+++ b/amazonAlexa.cfc
@@ -2,10 +2,11 @@
 	<cffunction name="init" access="public" returntype="amazonAlexa" >
 		<cfargument name="awsAccessKeyId" type="string" required="true"/>
 		<cfargument name="secretAccessKey" type="string" required="true"/>
+		<cfargument name="endPoint" type="string" required="true" default="awis.amazonaws.com"/>
 				
 		<cfset variables.awsAccessKeyId = arguments.awsAccessKeyId />
 		<cfset variables.secretAccesskey = arguments.secretAccessKey />
-		<cfset variables.endPoint = 'awis.amazonaws.com' />
+		<cfset variables.endPoint = arguments.endPoint />
 		<cfset variables.requestMethod = 'no-header' />
 		<cfset variables.version = '' />
 		<cfset variables.protocol = 'http://' />

--- a/amazonAutoScaling.cfc
+++ b/amazonAutoScaling.cfc
@@ -2,10 +2,11 @@
 	<cffunction name="init" access="public" returntype="amazonAutoScaling" >
 		<cfargument name="awsAccessKeyId" type="string" required="true"/>
 		<cfargument name="secretAccessKey" type="string" required="true"/>
+		<cfargument name="endPoint" type="string" required="true" default="autoscaling.us-east-1.amazonaws.com"/>
 				
 		<cfset variables.awsAccessKeyId = arguments.awsAccessKeyId />
 		<cfset variables.secretAccesskey = arguments.secretAccessKey />
-		<cfset variables.endPoint = 'autoscaling.us-east-1.amazonaws.com' />
+		<cfset variables.endPoint = arguments.endPoint />
 		<cfset variables.requestMethod = 'no-header' />
 		<cfset variables.version = '2011-01-01' />
 		<cfset variables.protocol = 'https://' />

--- a/amazonBeanstalk.cfc
+++ b/amazonBeanstalk.cfc
@@ -2,10 +2,11 @@
 	<cffunction name="init" access="public" returntype="amazonBeanstalk" >
 		<cfargument name="awsAccessKeyId" type="string" required="true"/>
 		<cfargument name="secretAccessKey" type="string" required="true"/>
+		<cfargument name="endPoint" type="string" required="true" default="elasticbeanstalk.us-east-1.amazonaws.com"/>
 				
 		<cfset variables.awsAccessKeyId = arguments.awsAccessKeyId />
 		<cfset variables.secretAccesskey = arguments.secretAccessKey />
-		<cfset variables.endPoint = 'elasticbeanstalk.us-east-1.amazonaws.com' />
+		<cfset variables.endPoint = arguments.endPoint />
 		<cfset variables.requestMethod = 'no-header' />
 		<cfset variables.version = '2010-12-01' />
 		<cfset variables.protocol = 'https://' />

--- a/amazonCloudFormation.cfc
+++ b/amazonCloudFormation.cfc
@@ -2,10 +2,11 @@
 	<cffunction name="init" access="public" returntype="amazonCloudFormation" >
 		<cfargument name="awsAccessKeyId" type="string" required="true"/>
 		<cfargument name="secretAccessKey" type="string" required="true"/>
+		<cfargument name="endPoint" type="string" required="true" default="cloudformation.us-east-1.amazonaws.com"/>
 				
 		<cfset variables.awsAccessKeyId = arguments.awsAccessKeyId />
 		<cfset variables.secretAccesskey = arguments.secretAccessKey />
-		<cfset variables.endPoint = 'cloudformation.us-east-1.amazonaws.com' />
+		<cfset variables.endPoint = arguments.endPoint />
 		<cfset variables.requestMethod = 'no-header' />
 		<cfset variables.version = '2010-05-15' />
 		<cfset variables.protocol = 'https://' />

--- a/amazonCloudWatch.cfc
+++ b/amazonCloudWatch.cfc
@@ -2,10 +2,11 @@
 	<cffunction name="init" access="public" returntype="amazonCloudWatch" >
 		<cfargument name="awsAccessKeyId" type="string" required="true"/>
 		<cfargument name="secretAccessKey" type="string" required="true"/>
+		<cfargument name="endPoint" type="string" required="true" default="monitoring.amazonaws.com"/>
 				
 		<cfset variables.awsAccessKeyId = arguments.awsAccessKeyId />
 		<cfset variables.secretAccesskey = arguments.secretAccessKey />
-		<cfset variables.endPoint = 'monitoring.amazonaws.com' />
+		<cfset variables.endPoint = arguments.endPoint />
 		<cfset variables.requestMethod = 'no-header' />
 		<cfset variables.version = '2010-08-01' />
 		<cfreturn this />		

--- a/amazonEC2.cfc
+++ b/amazonEC2.cfc
@@ -2,10 +2,11 @@
 	<cffunction name="init" access="public" returntype="amazonEC2" >
 		<cfargument name="awsAccessKeyId" type="string" required="true"/>
 		<cfargument name="secretAccessKey" type="string" required="true"/>
+		<cfargument name="endPoint" type="string" required="true" default="ec2.amazonaws.com"/>
 				
 		<cfset variables.awsAccessKeyId = arguments.awsAccessKeyId />
 		<cfset variables.secretAccesskey = arguments.secretAccessKey />
-		<cfset variables.endPoint = 'ec2.amazonaws.com' />
+		<cfset variables.endPoint = arguments.endPoint />
 		<cfset variables.requestMethod = 'no-header' />
 		<cfset variables.version = '2012-03-01' />
 		<cfset variables.protocol = 'https://' />

--- a/amazonElastiCache.cfc
+++ b/amazonElastiCache.cfc
@@ -2,10 +2,11 @@
 	<cffunction name="init" access="public" returntype="amazonElastiCache" >
 		<cfargument name="awsAccessKeyId" type="string" required="true"/>
 		<cfargument name="secretAccessKey" type="string" required="true"/>
+		<cfargument name="endPoint" type="string" required="true" default="elasticache.us-east-1.amazonaws.com"/>
 				
 		<cfset variables.awsAccessKeyId = arguments.awsAccessKeyId />
 		<cfset variables.secretAccesskey = arguments.secretAccessKey />
-		<cfset variables.endPoint = 'elasticache.us-east-1.amazonaws.com' />
+		<cfset variables.endPoint = arguments.endPoint />
 		<cfset variables.requestMethod = 'no-header' />
 		<cfset variables.version = '2012-03-09' />
 		<cfset variables.protocol = 'https://' />

--- a/amazonElasticLoadBalancing.cfc
+++ b/amazonElasticLoadBalancing.cfc
@@ -3,10 +3,11 @@
 	<cffunction name="init" access="public" returntype="amazonElasticLoadBalancing">
 		<cfargument name="awsAccessKeyId" type="string" required="true"/>
 		<cfargument name="secretAccessKey" type="string" required="true"/>
+		<cfargument name="endPoint" type="string" required="true" default="elasticloadbalancing.us-east-1.amazonaws.com"/>
 	
 		<cfset variables.awsAccessKeyId = arguments.awsAccessKeyId/>
 		<cfset variables.secretAccesskey = arguments.secretAccessKey/>
-		<cfset variables.endPoint = 'elasticloadbalancing.us-east-1.amazonaws.com'/>
+		<cfset variables.endPoint = arguments.endPoint />
 		<cfset variables.requestMethod = 'no-header'/>
 		<cfset variables.version = '2011-11-15'/>
 		<cfset variables.protocol = 'https://'/>

--- a/amazonFWS.cfc
+++ b/amazonFWS.cfc
@@ -2,10 +2,11 @@
 	<cffunction name="init" access="public" returntype="amazonFWS" >
 		<cfargument name="awsAccessKeyId" type="string" required="true"/>
 		<cfargument name="secretAccessKey" type="string" required="true"/>
+		<cfargument name="endPoint" type="string" required="true" default="fba-inbound.amazonaws.com"/>
 				
 		<cfset variables.awsAccessKeyId = arguments.awsAccessKeyId />
 		<cfset variables.secretAccesskey = arguments.secretAccessKey />
-		<cfset variables.endPoint = 'fba-inbound.amazonaws.com' />
+		<cfset variables.endPoint = arguments.endPoint />
 		<cfset variables.requestMethod = 'no-header' />
 		<cfset variables.version = '2007-05-10' />
 		<cfset variables.protocol = 'https://' />

--- a/amazonIAM.cfc
+++ b/amazonIAM.cfc
@@ -2,10 +2,11 @@
 	<cffunction name="init" access="public" returntype="amazonIAM" >
 		<cfargument name="awsAccessKeyId" type="string" required="true"/>
 		<cfargument name="secretAccessKey" type="string" required="true"/>
+		<cfargument name="endPoint" type="string" required="true" default="iam.amazonaws.com"/>
 				
 		<cfset variables.awsAccessKeyId = arguments.awsAccessKeyId />
 		<cfset variables.secretAccesskey = arguments.secretAccessKey />
-		<cfset variables.endPoint = 'iam.amazonaws.com' />
+		<cfset variables.endPoint = arguments.endPoint />
 		<cfset variables.requestMethod = 'no-header' />
 		<cfset variables.version = '2010-05-08' />
 		<cfset variables.protocol = 'https://' />

--- a/amazonImportExport.cfc
+++ b/amazonImportExport.cfc
@@ -2,10 +2,11 @@
 	<cffunction name="init" access="public" returntype="amazonImportExport" >
 		<cfargument name="awsAccessKeyId" type="string" required="true"/>
 		<cfargument name="secretAccessKey" type="string" required="true"/>
+		<cfargument name="endPoint" type="string" required="true" default="importexport.amazonaws.com"/>
 				
 		<cfset variables.awsAccessKeyId = arguments.awsAccessKeyId />
 		<cfset variables.secretAccesskey = arguments.secretAccessKey />
-		<cfset variables.endPoint = 'importexport.amazonaws.com' />
+		<cfset variables.endPoint = arguments.endPoint />
 		<cfset variables.requestMethod = 'no-header' />
 		<cfset variables.version = '2010-06-01' />
 		<cfset variables.protocol = 'https://' />

--- a/amazonMapReduce.cfc
+++ b/amazonMapReduce.cfc
@@ -2,10 +2,11 @@
 	<cffunction name="init" access="public" returntype="amazonMapReduce" >
 		<cfargument name="awsAccessKeyId" type="string" required="true"/>
 		<cfargument name="secretAccessKey" type="string" required="true"/>
+		<cfargument name="endPoint" type="string" required="true" default="elasticmapreduce.amazonaws.com"/>
 				
 		<cfset variables.awsAccessKeyId = arguments.awsAccessKeyId />
 		<cfset variables.secretAccesskey = arguments.secretAccessKey />
-		<cfset variables.endPoint = 'elasticmapreduce.amazonaws.com' />
+		<cfset variables.endPoint = arguments.endPoint />
 		<cfset variables.requestMethod = 'no-header' />
 		<cfset variables.version = '2009-03-31' />
 		<cfset variables.protocol = 'https://' />

--- a/amazonSES.cfc
+++ b/amazonSES.cfc
@@ -2,10 +2,12 @@
 	<cffunction name="init" access="public" returntype="amazonSES" >
 		<cfargument name="awsAccessKeyId" type="string" required="true"/>
 		<cfargument name="secretAccessKey" type="string" required="true"/>
+		<cfargument name="endPoint" type="string" required="true" default="sns.us-east-1.amazonaws.com"/>
 				
 		<cfset variables.awsAccessKeyId = arguments.awsAccessKeyId />
 		<cfset variables.secretAccesskey = arguments.secretAccessKey />
-		<cfset variables.endPoint = 'https://email.us-east-1.amazonaws.com' />
+		<cfset variables.endPoint = arguments.endPoint />
+		
 		<cfset variables.requestMethod = '' />
 		<cfreturn this />		
 	</cffunction>	

--- a/amazonSNS.cfc
+++ b/amazonSNS.cfc
@@ -2,10 +2,11 @@
 	<cffunction name="init" access="public" returntype="amazonSNS" >
 		<cfargument name="awsAccessKeyId" type="string" required="true"/>
 		<cfargument name="secretAccessKey" type="string" required="true"/>
+		<cfargument name="endPoint" type="string" required="true" default="sns.us-east-1.amazonaws.com" />
 				
 		<cfset variables.awsAccessKeyId = arguments.awsAccessKeyId />
 		<cfset variables.secretAccesskey = arguments.secretAccessKey />
-		<cfset variables.endPoint = 'sns.us-east-1.amazonaws.com' />
+		<cfset variables.endPoint = arguments.endPoint />
 		<cfset variables.requestMethod = 'no-header' />
 		<cfreturn this />		
 	</cffunction>	

--- a/amazonSQS.cfc
+++ b/amazonSQS.cfc
@@ -2,10 +2,11 @@
 	<cffunction name="init" access="public" returntype="amazonSQS" >
 		<cfargument name="awsAccessKeyId" type="string" required="true"/>
 		<cfargument name="secretAccessKey" type="string" required="true"/>
+		<cfargument name="endPoint" type="string" required="true" default="sqs.us-east-1.amazonaws.com"/>
 				
 		<cfset variables.awsAccessKeyId = arguments.awsAccessKeyId />
 		<cfset variables.secretAccesskey = arguments.secretAccessKey />
-		<cfset variables.endPoint = 'sqs.us-east-1.amazonaws.com' />
+		<cfset variables.endPoint = arguments.endPoint />
 		<cfset variables.requestMethod = 'no-header' />
 		<cfset variables.version = '2011-10-01' />
 		<cfreturn this />		
@@ -112,10 +113,9 @@
 	
 	<cffunction name="ReceiveMessage" access="public" returntype="Struct" >
 		<cfargument name="Queue" type="string" required="true" >
-		<cfargument name="MaxNumberOfMessages" type="string" required="false" default="" >
-		<cfargument name="VisibilityTimeout" type="string" required="false" default="" >
+		<cfargument name="MaxNumberOfMessages" type="string" required="false" default="10" >
+		<cfargument name="VisibilityTimeout" type="string" required="false" default="30" >
 		<cfargument name="AttributeName" type="string" required="false" default="" hint="Valid values: All | SenderId | SentTimestamp | ApproximateReceiveCount | ApproximateFirstReceiveTimestamp" >
-		
 		<cfset var stResponse = createResponse() />
 		<cfset var body = "Action=ReceiveMessage" />
 		

--- a/amazonSTS.cfc
+++ b/amazonSTS.cfc
@@ -2,10 +2,11 @@
 	<cffunction name="init" access="public" returntype="amazonSTS" >
 		<cfargument name="awsAccessKeyId" type="string" required="true"/>
 		<cfargument name="secretAccessKey" type="string" required="true"/>
+		<cfargument name="endPoint" type="string" required="true" default="sts.amazonaws.com"/>
 				
 		<cfset variables.awsAccessKeyId = arguments.awsAccessKeyId />
 		<cfset variables.secretAccesskey = arguments.secretAccessKey />
-		<cfset variables.endPoint = 'sts.amazonaws.com' />
+		<cfset variables.endPoint = arguments.endPoint />
 		<cfset variables.requestMethod = 'no-header' />
 		<cfset variables.version = '2011-06-15' />
 		<cfset variables.protocol = 'https://' />

--- a/amazonSWS.cfc
+++ b/amazonSWS.cfc
@@ -2,10 +2,11 @@
 	<cffunction name="init" access="public" returntype="amazonSWS" >
 		<cfargument name="awsAccessKeyId" type="string" required="true"/>
 		<cfargument name="secretAccessKey" type="string" required="true"/>
+		<cfargument name="endPoint" type="string" required="true" default="https://swf.us-east-1.amazonaws.com"/>
 				
 		<cfset variables.awsAccessKeyId = arguments.awsAccessKeyId />
 		<cfset variables.secretAccesskey = arguments.secretAccessKey />
-		<cfset variables.endPoint = 'https://swf.us-east-1.amazonaws.com' />
+		<cfset variables.endPoint = arguments.endPoint />
 		<cfset variables.requestMethod = '' />
 		<cfset variables.version = '2012-01-25' />
 		<cfset variables.protocol = 'https://' />

--- a/amazonSimpleDB.cfc
+++ b/amazonSimpleDB.cfc
@@ -2,10 +2,11 @@
 	<cffunction name="init" access="public" returntype="amazonSimpleDB" >
 		<cfargument name="awsAccessKeyId" type="string" required="true"/>
 		<cfargument name="secretAccessKey" type="string" required="true"/>
+		<cfargument name="endPoint" type="string" required="true" default="sdb.amazonaws.com"/>
 				
 		<cfset variables.awsAccessKeyId = arguments.awsAccessKeyId />
 		<cfset variables.secretAccesskey = arguments.secretAccessKey />
-		<cfset variables.endPoint = 'sdb.amazonaws.com' />
+		<cfset variables.endPoint = arguments.endPoint />
 		<cfset variables.requestMethod = 'no-header' />
 		<cfset variables.version = '2009-04-15' />
 		<cfreturn this />		


### PR DESCRIPTION
Simon,

We are using a few of your AWS CFCs. Thank you for providing them.

In some cases, we have needed a different end point. It felt wrong to hard-code them. So, I added them as init args. Today I decided to contribute back. So, I updated all of the CFCs.

Here is what I did:

Updated all of the init methods of the CFCs to take an "endPoint" argument. 
Defaulted the endPoint argument to what it was hard-coded to originally.
Set the variables.endPoint to arguments.endPoint.
